### PR TITLE
Add support for multiple servers in upstream blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ To generate upstream configuration like this:
 ```
 upstream app_123 {
   server 127.0.0.1:12380;
+  server api.example.com;
+  server api2.example.com:1234 fail_timeout=60 max_fails=3;
+  server unix:/tmp/api3.sock;
 }
 ```
 
@@ -31,8 +34,12 @@ do:
 ```ruby
 upstream = NginxConfigMaker::Upstream.new(
   name: "app_123",
-  host: "127.0.0.1",
-  port: "12380",
+  instances: [
+    {host: "127.0.0.1",port:12380},
+    {host: "api.example.com"},
+    {host: "api2.example.com", port:1234, fail_timeout:60, max_fails:3}
+    {host: "unix:/tmp/api3.sock"}
+  ]
 )
 upstream.to_s
 ```

--- a/lib/nginx_config_maker.rb
+++ b/lib/nginx_config_maker.rb
@@ -4,6 +4,7 @@ require "nginx_config_maker/server"
 require "nginx_config_maker/location"
 require "nginx_config_maker/proxy"
 require "nginx_config_maker/proxy_set_headers"
+require "nginx_config_maker/instance"
 
 module NginxConfigMaker
 end

--- a/lib/nginx_config_maker/instance.rb
+++ b/lib/nginx_config_maker/instance.rb
@@ -1,0 +1,28 @@
+module NginxConfigMaker
+  class Instance
+
+    attr_reader :host, :port, :weight, :down, :max_fails, :fail_timeout,:slow_start
+
+    def initialize(opts)
+      @host = opts.fetch(:host)
+      @port = opts[:port]
+      @weight = opts[:weight]
+      @down = opts[:down]
+      @max_fails = opts[:max_fails]
+      @fail_timeout = opts[:fail_timeout]
+      @backup = opts[:backup]
+    end
+
+    def to_s
+      server_address = @port ? "#{@host}:#{@port}" : @host
+      config = ["  server #{server_address}"]
+      config << "max_fails=#{@max_fails}" if @max_fails
+      config << "weight=#{@weight}" if @weight
+      config << "down" if @down
+      config << "fail_timeout=#{@fail_timeout}" if @fail_timeout
+      config << "slow_start=#{@slow_start}" if @slow_start
+      "#{config.join(" ")};"
+    end
+
+  end
+end

--- a/lib/nginx_config_maker/upstream.rb
+++ b/lib/nginx_config_maker/upstream.rb
@@ -1,18 +1,16 @@
 module NginxConfigMaker
   class Upstream
 
-    attr_reader :name, :host, :port
+    attr_reader :name, :instances
 
     def initialize(opts)
       @name = opts.fetch(:name)
-      @host = opts.fetch(:host)
-      @port = opts.fetch(:port)
+      @instances = opts.fetch(:instances).map{|inst| Instance.new(inst)}
     end
 
     def to_s
       config = ["upstream #{name} {"]
-      host_and_port = [host, port].join(":")
-      config << "  server #{host_and_port};"
+      config << @instances.map(&:to_s).join("\n")
       config << "}"
       config.join("\n")
     end

--- a/spec/nginx_config_maker/upstream_spec.rb
+++ b/spec/nginx_config_maker/upstream_spec.rb
@@ -7,13 +7,27 @@ module NginxConfigMaker
       it "returns a upstream nginx config string for the given options" do
         config = described_class.new(
           name: "app_123",
-          host: "127.0.0.1",
-          port: "12380",
+          instances: [
+            {host: "127.0.0.1",port: "12380"},
+            {host: "127.0.0.1",port: "12381"},
+            {host: "www.example.com"},
+            {host: "app1.example.com", weight:2},
+            {host: "app2.example.com", weight:2},
+            {host: "app3.example.com", weight:1},
+            {host: "unix:/tmp/app4.sock"}
+          ]
+          
         )
 
         expected_config = <<-EOQ.dedent
           upstream app_123 {
             server 127.0.0.1:12380;
+            server 127.0.0.1:12381;
+            server www.example.com;
+            server app1.example.com weight=2;
+            server app2.example.com weight=2;
+            server app3.example.com weight=1;
+            server unix:/tmp/app4.sock;
           }
         EOQ
 


### PR DESCRIPTION
In order to support load balancing, one upstream block needs to
configure multiple server instances. This commit adds the following load
balancing configuration options:

host(mandatory), port,weight,fail_timeout,max_fails,backup and down. Most of these are
optional to ease configuration.

The host can be a unix socket.

This will be a _breaking change_ in the sense that Upstream objects now
have a different initialize method.
